### PR TITLE
Add hal9 to private-data

### DIFF
--- a/site/content/private-data/hal9.md
+++ b/site/content/private-data/hal9.md
@@ -1,0 +1,11 @@
++++
+title = "Hal9"
+weight = 40
+[extra]
+linkURL = "https://hal9.com/"
+description = "Hal9 enables using LLMs with private data from databases, CSVs, and others by generating and running python code."
+additionalLinks = [
+  { url = "https://github.com/hal9ai/hal9", icon = "/icons/github.svg", tooltip = "GitHub Repository" },
+  { url = "https://hal9.com/", icon = "/icons/documentation.svg", tooltip = "Documentation" },
+]
++++

--- a/site/content/private-data/hal9.md
+++ b/site/content/private-data/hal9.md
@@ -2,10 +2,10 @@
 title = "Hal9"
 weight = 40
 [extra]
-linkURL = "https://hal9.com/"
+linkURL = "https://hal9.com/?ref=lbai"
 description = "Hal9 enables using LLMs with private data from databases, CSVs, and others by generating and running python code."
 additionalLinks = [
   { url = "https://github.com/hal9ai/hal9", icon = "/icons/github.svg", tooltip = "GitHub Repository" },
-  { url = "https://hal9.com/", icon = "/icons/documentation.svg", tooltip = "Documentation" },
+  { url = "https://hal9.com/docs", icon = "/icons/documentation.svg", tooltip = "Documentation" },
 ]
 +++


### PR DESCRIPTION
Adds [hal9.com](https://hal9.com) to `private-data` category.