### PR TITLE
Add Airtrain playground reference

### DIFF
--- a/site/content/playground/airtrain.md
+++ b/site/content/playground/airtrain.md
@@ -1,0 +1,7 @@
++++
+title = "Airtrain"
+weight = 20
+[extra]
+linkURL = "https://www.airtrain.ai/"
+description = "Play with OSS and proprietary models via Airtrain's playground."
++++


### PR DESCRIPTION
Airtrain offers a playground where you can instruction-prompt multiple models at once, both proprietary and open. This adds a link to Airtrain for the playground section.