### PR TITLE
Rename Apple MLX to MLX

### DIFF
--- a/site/content/model-development/mlx.md
+++ b/site/content/model-development/mlx.md
@@ -1,5 +1,5 @@
 +++
-title = "MLX"
+title = "MLX (Apple silicon)"
 weight = 60
 [extra]
 linkURL = "https://github.com/ml-explore/mlx"

--- a/site/content/model-development/mlx.md
+++ b/site/content/model-development/mlx.md
@@ -1,5 +1,5 @@
 +++
-title = "Apple MLX"
+title = "MLX"
 weight = 60
 [extra]
 linkURL = "https://github.com/ml-explore/mlx"


### PR DESCRIPTION
IMO it should be called MLX, not Apple MLX. The same way we just say TensorFlow, PyTorch, JAX without referring to Google or Meta.