### PR TITLE
Add Serp API category

### DIFF
--- a/site/content/serp-api/_index.md
+++ b/site/content/serp-api/_index.md
@@ -1,0 +1,1 @@
++++ title = "SERP API" sort_by = "weight" +++

--- a/site/content/serp-api/serpapi.md
+++ b/site/content/serp-api/serpapi.md
@@ -1,0 +1,11 @@
++++
+title = "SerpApi"
+weight = 10
+[extra]
+linkURL = "https://serpapi.com/"
+description = "Scrape Google and other search engines from our fast, easy, and complete API."
+additionalLinks = [
+  { url = "https://github.com/serpapi/", icon = "/icons/github.svg", tooltip = "GitHub Repository" },
+  { url = "https://serpapi.com/", icon = "/icons/documentation.svg", tooltip = "Documentation" },
+]
++++

--- a/site/etc/categories.json
+++ b/site/etc/categories.json
@@ -29,6 +29,7 @@
     { "path": "cloud-providers/_index.md", "title_bar_color": "bg-blue-600", "background_color": "bg-blue-50" },
     { "path": "image-generation/_index.md", "title_bar_color": "bg-orange-600", "background_color": "bg-orange-50" },
     { "path": "people/_index.md", "title_bar_color": "bg-purple-600", "background_color": "bg-purple-50" }
+    { "path": "serp-api/_index.md", "title_bar_color": "bg-blue-600", "background_color": "bg-blue-50" }
   ]
 }
 


### PR DESCRIPTION
To get some real-time data, an AI model can learn or grab from publicly available data like Google Search, Google News, etc.. I'm adding serpapi.com as the first item on the list as well.